### PR TITLE
Add Becker method to return all configured units

### DIFF
--- a/pybecker/becker.py
+++ b/pybecker/becker.py
@@ -230,3 +230,10 @@ class Becker:
             :type channel: str
         """
         await self.send(channel, "TRAIN")
+
+    async def list_units(self):
+        """
+        Return all configured units as a list.
+        """
+
+        return self.db.get_all_units()


### PR DESCRIPTION
Allows logging/listing of all configured units within e.g. Home Assistant