### PR TITLE
Allow to use specific DB file location

### DIFF
--- a/pybecker/becker.py
+++ b/pybecker/becker.py
@@ -45,7 +45,7 @@ class Becker:
         Use this class to perform operations on your Becker Shutter using a centronic USB Stick
         This class will as well maintain a call increment in an internal database
     """
-    def __init__(self, device_name=DEFAULT_DEVICE_NAME, init_dummy=False):
+    def __init__(self, device_name=DEFAULT_DEVICE_NAME, init_dummy=False, db_filename=None):
         """
             Create a new instance of the Becker controller
 
@@ -58,7 +58,7 @@ class Becker:
         if self.is_serial and not os.path.exists(device_name):
             raise BeckerConnectionError(device_name + " is not existing")
         self.device = device_name
-        self.db = Database()
+        self.db = Database(db_filename)
 
         # If no unit is defined create a dummy one
         units = self.db.get_all_units()

--- a/pybecker/database.py
+++ b/pybecker/database.py
@@ -12,8 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class Database:
 
-    def __init__(self):
-        self.filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'centronic-stick.db')
+    def __init__(self, filename=None):
+        self.filename = filename or os.path.join(os.path.dirname(os.path.realpath(__file__)), 'centronic-stick.db')
         self.conn = sqlite3.connect(self.filename)
         self.check()
 


### PR DESCRIPTION
When using this library in a Docker image it is easier to have the DB file at a specific location. For the default cause, the location "beside" the library is used, but with this PR you can modify the location to be more flexible.