### PR TITLE
Add UP2 and DOWN2 commands

### DIFF
--- a/pybecker/__main__.py
+++ b/pybecker/__main__.py
@@ -16,10 +16,14 @@ async def main():
 
     if args.action == "UP":
         await client.move_up(args.channel)
+    elif args.action == "UP2":
+        await client.move_up_intermediate(args.channel)
     elif args.action == "HALT":
         await client.stop(args.channel)
     elif args.action == "DOWN":
         await client.move_down(args.channel)
+    elif args.action == "DOWN2":
+        await client.move_down_intermediate(args.channel)
     elif args.action == "PAIR":
         await client.pair(args.channel)
 


### PR DESCRIPTION
Hi,

I've installed your pybecker script today and got it to work with my shutters, but I noticed that many of the extended commands available in the library aren't exposed by `__main__`. I've added two of the most useful ones and tested them successfully.