### PR TITLE
Update pybecker to add support to receive packets/commands from Becker Remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ pip install pybecker
 
 Usage
 -----
-The goal of this library is to be used in your home automation component. 
+The goal of this library is to be used in your home automation component.
 however after installation you can test it by runing
 ```console
-pybecker -a <UP|DOWN|PAIR|HALT> -c <CHANNEL>
+python -m pybecker -a <UP|DOWN|PAIR|HALT> -c <CHANNEL>
 ```

--- a/pybecker/becker_helper.py
+++ b/pybecker/becker_helper.py
@@ -1,4 +1,13 @@
 import logging
+import re
+import time
+import threading
+import queue
+from typing import Any, Callable, Tuple
+import os
+import sys
+import serial
+import serial.tools.list_ports
 
 STX = b'\x02'
 ETX = b'\x03'
@@ -7,6 +16,25 @@ CODE_PREFIX = "0000000002010B"  # 0-23 (24 chars)
 CODE_SUFFIX = "000000"
 CODE_21 = "021"
 CODE_REMOTE = "01"  # centronic remote control used "02" while contralControl seem to use "01"
+
+DEFAULT_DEVICE_NAME = '/dev/serial/by-id/usb-BECKER-ANTRIEBE_GmbH_CDC_RS232_v125_Centronic-if00'
+
+MESSAGE = re.compile(
+      STX
+    + CODE_PREFIX.encode()
+    + rb'[0-9A-F]{4,4}'
+    + CODE_SUFFIX.encode()
+    + rb'(?P<unit_id>[0-9A-F]{5,5})'
+    + rb'[0-9A-F]{6,6}'
+    + rb'(?P<channel>[0-9A-F]{1,1})'
+    + rb'00'
+    + rb'(?P<command>[124]{1,1})'            # HALT, UP, DOWN
+    + rb'(?P<argument>[0-9A-F]{1,1})'
+    + rb'[0-9A-F]{2,2}'
+    + ETX, re.I
+)
+
+COMMANDS = {b'1': 'HALT', b'2': 'UP', b'4': 'DOWN'}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,3 +80,208 @@ def finalize_code(code):
 
 class BeckerConnectionError(Exception):
     pass
+
+
+class BeckerConnection():
+    """
+    Connection class for Becker centronic USB Stick.
+    """
+    def __init__(self, device: str) -> None:
+        """Initialize connection."""
+        self._device, self._is_serial = self._validate_device(device)
+        try:
+            self._connection = serial.serial_for_url(
+                self.device,
+                baudrate=115200,
+                timeout=0,
+                do_not_open = True
+            )
+        except serial.SerialException as err:
+            raise BeckerConnectionError(
+                "Error when trying to establish connection using {}.".format(self.device)
+            ) from err
+        self._open()
+
+    @property
+    def is_serial(self) -> bool:
+        """Return if device is serial port."""
+        return self._is_serial
+
+    @property
+    def device(self) -> str:
+        """Return device name."""
+        return self._device
+
+    def write(self, packet: bytes) -> None:
+        """Write data."""
+        self._open()
+        try:
+            self._connection.write(packet)
+        except serial.SerialException:
+            if self._is_serial:
+                raise
+            # Re-connect on error
+            _LOGGER.debug("Write failed. Try to close and re-open connection to %s", self.device)
+            self._connection.close()
+            self._open()
+            self._connection.write(packet)
+
+    def read(self) -> bytes:
+        """Read data."""
+        packet = bytes()
+        self._open()
+        try:
+            packet = self._connection.read(1024)
+        except serial.SerialException:
+            if self._is_serial:
+                raise
+            # Re-connect on error
+            _LOGGER.debug("Read failed. Try to close and re-open connection to %s", self.device)
+            self._connection.close()
+        return packet
+
+    def _open(self) -> None:
+        if not self._connection.is_open:
+            _LOGGER.debug("Try to open connection.")
+            try:
+                self._connection.open()
+            except serial.SerialException as err:
+                if self.is_serial:
+                    raise BeckerConnectionError(
+                        "Error when trying to establish connection using {}.".format(self.device)
+                    ) from err
+                _LOGGER.error("Establish connection to %s failed!", self.device)
+            except:     # pylint: disable=bare-except
+                _LOGGER.error("Establish connection to %s failed!", self.device)
+
+    def close(self) -> None:
+        """Close connection"""
+        if self._connection.is_open:
+            self._connection.close()
+
+    @staticmethod
+    def _validate_device(device: str) -> Tuple[str, bool]:
+        """Validate device name."""
+        is_serial = False
+        is_socket = True
+        if device is None:
+            device = DEFAULT_DEVICE_NAME
+        if "/dev/" in device:
+            if not os.path.exists(device):
+                raise BeckerConnectionError("{} is not existing".format(device))
+            is_serial = True
+            is_socket = False
+        elif sys.platform.startswith('win') and 'COM' in device.upper():
+            if not device.upper() in [i.device for i in serial.tools.list_ports.comports()]:
+                raise BeckerConnectionError("{} is not existing".format(device))
+            is_serial = True
+            is_socket = False
+        elif "/" in device:
+            is_socket = False
+        if is_socket:
+            if ':' in device:
+                host, port = device.split(':', 1)
+            else:
+                host = device
+                port = '5000'
+            device = f'socket://{host}:{port}'
+        return device, is_serial
+
+
+class BeckerCommunicator(threading.Thread):
+    """
+    Communicator class for Becker centronic USB Stick.
+    """
+    def __init__(
+        self,
+        device: str,
+        callback: Callable[[re.Match], Any] = None,
+        deamon: bool = True,
+    ) -> None:
+        '''Initialize communicator'''
+        super().__init__(daemon=deamon)
+        # Setup threading stop event and queue
+        self._stop_flag = threading.Event()
+        self._write_queue = queue.Queue(maxsize=100)
+        # Setup callback
+        self._callback = callback
+        # Setup interface
+        self._connection = BeckerConnection(device=device)
+        self._read_buffer = bytes()
+
+    def run(self) -> None:
+        '''Run BeckerCommunicator thread.'''
+        _LOGGER.debug('BeckerCommunicator thread started.')
+        callback_valid = False if self._callback is None else True    # pylint: disable=simplifiable-if-expression
+        packet = None
+        while True:
+            # Get packet from write queue
+            try:
+                packet = self._write_queue.get(block=False)
+            except queue.Empty:
+                pass
+            else:
+                self._connection.write(packet)
+                self._log(packet, "Sent packet: ")
+            # Read bytes from serial port
+            if callback_valid:
+                self._read_buffer += self._connection.read()
+                self._parse()
+            # Sleep for thread switch and wait time between packets
+            time.sleep(0.01)
+            # Ensure all packets in queue are send before thread is stopped
+            if self._stop_flag.is_set() and self._write_queue.empty():
+                break
+        _LOGGER.debug('BeckerCommunicator thread stopped.')
+
+    def stop(self) -> None:
+        '''Stop BeckerCommunicator thread.'''
+        self._stop_flag.set()
+
+    def _parse(self) -> None:
+        """Parse received packets and run callback."""
+        end = 0
+        for data in MESSAGE.finditer(self._read_buffer):
+            self._log(data.group(0), "Received packet: ")
+            self._callback(data)
+            end = data.end()
+        self._read_buffer = self._read_buffer[end:]
+
+    def _log(self, packet: bytes, text: str = "") -> None:
+        """Log packets."""
+        if _LOGGER.getEffectiveLevel() <= logging.DEBUG:
+            match = MESSAGE.search(packet)
+            if match is not None:
+                if match.group('command') in COMMANDS:
+                    command = COMMANDS[match.group('command')]
+                else:
+                    command = match.group('command').decode()
+                _LOGGER.debug(
+                    "%sunit_id: %s, channel: %s, command: %s, argument: %s, packet: %s",
+                    text,
+                    match.group('unit_id').decode(),
+                    match.group('channel').decode(),
+                    command,
+                    match.group('argument').decode(),
+                    match.group(0),
+                )
+
+    def send(self, packet) -> None:
+        """Send packet."""
+        if not self.is_alive():
+            raise BeckerConnectionError(
+                "Error BeckerCommunicator thread not alive."
+            )
+        try:
+            self._write_queue.put(packet, timeout=5)
+        except queue.Full as err:
+            self.stop()
+            raise BeckerConnectionError(
+                "Error sending packet. BeckerCommunicator thread not responding."
+            ) from err
+
+    def close(self) -> None:
+        """Stop thread and close device"""
+        self.stop()
+        self.join(timeout=5)
+        self._connection.close()

--- a/pybecker/database.py
+++ b/pybecker/database.py
@@ -6,6 +6,8 @@ from random import randrange
 from .becker_helper import hex4
 
 NUMBER_FILE = "centronic-stick.num"
+SQL_DB_FILE = "centronic-stick.db"
+FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 class Database:
 
     def __init__(self, filename=None):
-        self.filename = filename or os.path.join(os.path.dirname(os.path.realpath(__file__)), 'centronic-stick.db')
+        self.filename = filename or os.path.join(FILE_PATH, SQL_DB_FILE)
         self.conn = sqlite3.connect(self.filename)
         self.check()
 
@@ -34,7 +36,7 @@ class Database:
     def migrate(self):
         try:
             # migrate the previous *.num file into its sqllite database
-            self.old_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), NUMBER_FILE)
+            self.old_file = os.path.join(FILE_PATH, NUMBER_FILE)
             if os.path.isfile(self.old_file):
                 _LOGGER.info('Migrate previous *.num file...')
                 with open(self.old_file, "r") as file:


### PR DESCRIPTION
Thanks for your work on pybecker and the HA cover integration. Without your work I would not been able to implement this into my HA.

As I'm using 5 covers with Becker Remotes, I spent quite a lot of time to find out the best way to receive packets from Becker Remotes. My goal was to instant receive the packets in HA. This allows to track the position of the cover even when it is operated by a Becker Remote.

At first the easiest way seems to receive the packets by polling. To receive packets instant, a poling time between 0.1 - 1 second is required. But this caused a high CPU load of HA. Also using DataUpdateCoordinator does not improve CPU load. I even had a fatal Python Segmentation fault crash of HA after some days.

I was looking for similar integrations polling packets from an USB stick and found the enocean integration. They are using a communicator thread for serial communication. 
I wrote BeckerConnection to handle serial connection as well as socket connection. I found serial.serial_for_url already supports several kinds of connections. Now all kinds of connections from serial.serial_for_url are supported. I also kept the reconnect on socket connection errors.
The BeckerCommunicator is the threading Thread responsible to send and receive packets. Received packets will be parsed for valid data and send to a callback function as a re.match object.

With this implementation instant receive of packets work well without increased CPU load of HA.
Unfortunately this caused a lot more changes I wanted to do.

My updated hass-becker-component with local pybecker module can be found here:
[hass-becker-component](https://github.com/RainerStaude/hass-becker-component-plus-pybecker)

I would be happy if you find some time to implement the changes into your pybecker module.